### PR TITLE
Add parens to print and it works in Python 3 too.

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -56,4 +56,4 @@ try:
 finally:
     curses.endwin()
 for line in lines:
-    print line
+    print(line)


### PR DESCRIPTION
Change the "print line" to "print(line)" and it works in Python 3.
It still works in Python 2 as well.
