### PR TITLE
[FIX] proper printing of chars (for ex. from 'tree') for python3

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -60,7 +60,7 @@ def iterate(increase=False):
                                  random.choice(string.punctuation),
                                  curses.A_REVERSE)
                 else:
-                    screen.addch(line_num - first_line, col, line[col])
+                    screen.addstr(line_num - first_line, col, line[col])
             except:
                 pass
 

--- a/decrypt/__init__.pt
+++ b/decrypt/__init__.pt
@@ -1,0 +1,4 @@
+from decrypt import main
+
+if __name__ == "__main__":
+    main()

--- a/decrypt/decrypt.py
+++ b/decrypt/decrypt.py
@@ -68,5 +68,3 @@ def iterate(increase=False):
     time.sleep(0.1)
     return still_random > 0
 
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     long_description = open('README.md').read(),
     author           = "jtwaleson",
     url              = "https://github.com/jtwaleson/decrypt",
-    packages         = find_packages(), #["decrypt"],
-    entry_points     = {'console_scripts': ['decrypt = decrypt:main']},
+    packages         = ["decrypt"],
+    entry_points     = {'console_scripts': ['decrypt = decrypt.decrypt:main']},
 )


### PR DESCRIPTION
Fixes issue#2 for python3. Python2 is a bit trickier and I couldn't figure it out yet.

Problem was that `addch` uses a `C` char, and `addstr` uses `string`.
